### PR TITLE
upgpkg: bruno-bin 2.13.2-1

### DIFF
--- a/bruno-bin/.SRCINFO
+++ b/bruno-bin/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = bruno-bin
 	pkgdesc = Opensource API Client for Exploring and Testing APIs
-	pkgver = 2.13.1
+	pkgver = 2.13.2
 	pkgrel = 1
 	url = https://www.usebruno.com/
 	arch = x86_64
@@ -13,9 +13,9 @@ pkgbase = bruno-bin
 	depends = alsa-lib
 	provides = bruno
 	conflicts = bruno
-	source = https://github.com/usebruno/bruno/releases/download/v2.13.1/bruno_2.13.1_amd64_linux.deb
-	source = LICENSE-2.13.1::https://raw.githubusercontent.com/usebruno/bruno/v2.13.1/license.md
-	sha256sums = 367b1495077d0ad01a39d5e188dd51d2a1802c0852a4d867af481934d3928fdc
+	source = https://github.com/usebruno/bruno/releases/download/v2.13.2/bruno_2.13.2_amd64_linux.deb
+	source = LICENSE-2.13.2::https://raw.githubusercontent.com/usebruno/bruno/v2.13.2/license.md
+	sha256sums = ea47660e7301a272cb0a36e68c2f5ace83da60a19f90d1cd337c246111dfc49b
 	sha256sums = 8891070a847e5047bf77d38d88d7dfbab1beab41e37c802b9f5b23f2bbb9c7be
 
 pkgname = bruno-bin

--- a/bruno-bin/PKGBUILD
+++ b/bruno-bin/PKGBUILD
@@ -3,7 +3,7 @@
 pkgname=bruno-bin
 _pkgname=bruno
 pkgdesc="Opensource API Client for Exploring and Testing APIs"
-pkgver=2.13.1
+pkgver=2.13.2
 pkgrel=1
 arch=('x86_64')
 url="https://www.usebruno.com/"
@@ -20,7 +20,7 @@ depends=(
 )
 
 sha256sums=(
-    "367b1495077d0ad01a39d5e188dd51d2a1802c0852a4d867af481934d3928fdc"
+    "ea47660e7301a272cb0a36e68c2f5ace83da60a19f90d1cd337c246111dfc49b"
     "8891070a847e5047bf77d38d88d7dfbab1beab41e37c802b9f5b23f2bbb9c7be"
 )
 


### PR DESCRIPTION
Update of binary package to latest available release. I was not able to get `bruno`, `bruno-git` to build because of the asar/node incompatibility.